### PR TITLE
Made Backup/Restore Android-6 ("M" api=23 released oktober 2015) and later compatible

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,9 +4,11 @@ v 250125 restructure file layout to make project compatible with gradle/androids
     done: able to compile and debug in adroidstudio
 v 250412 migrate to oldest androidX 1.0.0
 
+v 250414 implemented backup for android5ff with write-permissions+saf
+
 Sub-Goals
 
-* get rid of deprecated ListActivity
+> make backup/restore work again under android5 and later
+
+* * get rid of deprecated ListActivity
   * by replacing with AppCompatActivity + RecyclerView 
-* make backup/restore work again under android5 and later 
-* add app permission callback

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,14 @@ v 250414 implemented backup for android5ff with write-permissions+saf
 Sub-Goals
 
 > make backup/restore work again under android5 and later
+> > Backup for android5ff with write-permissions+saf
+* Backup with last dir or (on long press) with output-dir-picker. ??own menu/dialog with export specific settings??
+* backup error handling (ie "lost dir permission" or "outdir does not exist any more")
+* Method to create outfilename+extension (i.e. instead of name+ext+0): add yymmdd suffix
+* Restore for android5ff with write-permissions+saf
+* ?? add thumbs to backup/restore (?? to zip ??) so to avoid reload data from internet 
+* import/export as (?zipped?) csv, xmp. db. Export only md, html
+* refactor backup/restore logic to util modul
 
 * * get rid of deprecated ListActivity
   * by replacing with AppCompatActivity + RecyclerView 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     def appcompat_version = "1.0.2" // latest 1.0.x requires api 14
 
     implementation "androidx.appcompat:appcompat:$appcompat_version"
+    implementation "androidx.documentfile:documentfile:1.0.1"
 
     // implementation "androidx.recyclerview:recyclerview:1.4.0"
     // implementation "androidx.recyclerview:recyclerview:1.0.0" // not used yet

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.application'
 
 android {
+    buildFeatures {
+        buildConfig = true
+    }
     defaultConfig {
         applicationId "nl.asymmetrics.droidshows"
         minSdkVersion 14

--- a/app/src/main/java/nl/asymmetrics/droidshows/DroidShows.java
+++ b/app/src/main/java/nl/asymmetrics/droidshows/DroidShows.java
@@ -2169,14 +2169,17 @@ public class DroidShows extends ListActivity implements ActivityCompat.OnRequest
 	private void openDocumentFilePickForRestore() {
 		if (PermissionHelper.hasPermissionOrRequest(this, RESTORE_DB_PICKER_CODE)) {
 			// has permission. Ask for output dir
-			String mimetype = AndroidFileUtils.getDatabaseMimeType();
-
 			Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
 			intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
 					| Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
 					| Intent.FLAG_GRANT_PREFIX_URI_PERMISSION);
-			intent.setType(mimetype);
 			intent.addCategory(Intent.CATEGORY_OPENABLE);
+
+			// allow multible mime types for sqlite3 databases
+			// https://stackoverflow.com/questions/31301552/android-what-is-the-mime-type-to-use-if-i-want-to-see-pick-a-sqlite-database-fr
+			String[] mimeTypes = {"application/vnd.sqlite3", "application/x-sqlite3"};
+			intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
+			intent.setType("*/*");
 
 			Uri lastUsedBackupUri = getLastUsedBackupUri();
 			if (lastUsedBackupUri != null) intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI,lastUsedBackupUri);

--- a/app/src/main/java/nl/asymmetrics/droidshows/thetvdb/TheTVDBAndroid.java
+++ b/app/src/main/java/nl/asymmetrics/droidshows/thetvdb/TheTVDBAndroid.java
@@ -1,0 +1,22 @@
+package nl.asymmetrics.droidshows.thetvdb;
+
+import android.content.Context;
+
+import androidx.documentfile.provider.DocumentFile;
+
+import java.io.File;
+
+/**
+ * Android spezific code TheTVDB.
+ */
+public class TheTVDBAndroid {
+
+    public static void deleteThumbs(Context ctx) {
+        DocumentFile thumbsDir = DocumentFile.fromFile(new File(ctx.getFilesDir().getAbsolutePath() + "/thumbs/banners/posters"));
+        DocumentFile[] thumbs = (thumbsDir != null && thumbsDir.exists() && thumbsDir.isDirectory() ) ? thumbsDir.listFiles() : null;
+        if (thumbs != null)
+            for (DocumentFile thumb : thumbs)
+                thumb.delete();
+    }
+
+}

--- a/app/src/main/java/nl/asymmetrics/droidshows/utils/AndroidFileUtils.java
+++ b/app/src/main/java/nl/asymmetrics/droidshows/utils/AndroidFileUtils.java
@@ -1,0 +1,69 @@
+package nl.asymmetrics.droidshows.utils;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.webkit.MimeTypeMap;
+
+import androidx.annotation.NonNull;
+import androidx.documentfile.provider.DocumentFile;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/** Android specific file utilities */
+public class AndroidFileUtils {
+    public static @NonNull String getDatabaseMimeType() {
+        String mimetype = MimeTypeMap.getSingleton().getMimeTypeFromExtension("db");
+        if (TextUtils.isEmpty(mimetype)) mimetype = "*/*";
+        return mimetype;
+    }
+
+    /**
+     * deletes fileNames[fileNames.length - 1] and renames fileNames[i] to fileNames[i+1].
+     * As with all DocumentFile: Instead of IOExceptions the caller must check the boolean result of the function.
+     *
+     * @param destDir where all the files are processed
+     * @param fileNames 2 or more file names.
+     * @return false if something went wrong
+     */
+    public static boolean renameFiles(@NonNull DocumentFile destDir, String... fileNames) {
+        boolean success = true;
+        if (destDir == null || fileNames == null || fileNames.length < 2) {
+            throw new IllegalArgumentException("renameFiles needs an existing destDir and 2 or more file names");
+        }
+        int last = fileNames.length - 1;
+        DocumentFile file = destDir.findFile(fileNames[last]);
+        if (file != null && file.exists()) success = file.delete();
+
+        for (int i = last - 1; success && i >= 0; i --) {
+            file = destDir.findFile(fileNames[i]);
+            if (file != null && file.exists()) success = file.renameTo(fileNames[i + 1]);
+        }
+        return success;
+    }
+
+    public static void copyDocumentFile(@NonNull Context context,
+                                        @NonNull DocumentFile source,
+                                        @NonNull DocumentFile destination) throws IOException {
+        if (context == null || source == null || source == null) {
+            throw new IllegalArgumentException("copy: null arguments not allowed ");
+        }
+        InputStream in = null;
+        OutputStream out = null;
+        try {
+            in = context.getContentResolver().openInputStream(source.getUri());
+            out = context.getContentResolver().openOutputStream(destination.getUri());
+            IOUtils.copy(in, out);
+        } finally {
+            if (in != null) {
+                in.close();
+            }
+            if (out != null) {
+                out.close();
+            }
+        }
+    }
+}

--- a/app/src/main/java/nl/asymmetrics/droidshows/utils/AndroidFileUtils.java
+++ b/app/src/main/java/nl/asymmetrics/droidshows/utils/AndroidFileUtils.java
@@ -17,7 +17,11 @@ import java.io.OutputStream;
 public class AndroidFileUtils {
     public static @NonNull String getDatabaseMimeType() {
         String mimetype = MimeTypeMap.getSingleton().getMimeTypeFromExtension("db");
-        if (TextUtils.isEmpty(mimetype)) mimetype = "*/*";
+
+        // https://stackoverflow.com/questions/31301552/android-what-is-the-mime-type-to-use-if-i-want-to-see-pick-a-sqlite-database-fr
+        // Since Since Feb. 2018 application/vnd.sqlite3.
+        // The usage of application/x-sqlite3 is deprecated
+        if (TextUtils.isEmpty(mimetype)) mimetype = "application/vnd.sqlite3";
         return mimetype;
     }
 

--- a/app/src/main/java/nl/asymmetrics/droidshows/utils/PermissionHelper.java
+++ b/app/src/main/java/nl/asymmetrics/droidshows/utils/PermissionHelper.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2017-2025 k3b
+ *
+ * This file is part of nl.asymmetrics.droidshows (https://github.com/ltguillaume/droidshows) .
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>
+ */
+package nl.asymmetrics.droidshows.utils;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
+import android.widget.Toast;
+
+import nl.asymmetrics.droidshows.R;
+
+/**
+ * Support for android-6.0 (M) ff runtime permissons.
+ * Created by k3b on 23.12.2017.
+ *
+ * implements ActivityCompat.OnRequestPermissionsResultCallback
+ */
+
+public class PermissionHelper {
+    /**
+     * Id to identify a Storage permission request.
+     */
+    private static final int REQUEST_CODE_STORAGE = 215;
+
+    /**
+     * Permissions required to read and write Storage.
+     */
+    private static final String[] PERMISSIONS_STORAGE = {Manifest.permission.READ_EXTERNAL_STORAGE,
+            Manifest.permission.WRITE_EXTERNAL_STORAGE};
+    public static final boolean REQURES_PERMISSIONS = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
+
+    private PermissionHelper() {/*hide public constructor*/};
+    /**
+     * called before permission is required.
+     *
+     * @return true if has-permissions. else false and request permissions
+     * */
+    public static boolean hasPermissionOrRequest(Activity context) {
+        if (!hasPermission(context)) {
+            // Storage permission has not been requeste yet. Request for first time.
+            ActivityCompat.requestPermissions(context, PERMISSIONS_STORAGE, REQUEST_CODE_STORAGE);
+            // no permission yet
+            return false;
+        } // if android-m
+
+        // already has permission.
+        return true;
+    }
+
+    /**
+     * @return true if has-(runtime-)permissions.
+     * */
+    public static boolean hasPermission(Activity context) {
+        if (REQURES_PERMISSIONS) {
+            boolean needsRead = ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE)
+                    != PackageManager.PERMISSION_GRANTED;
+
+            boolean needsWrite = ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    != PackageManager.PERMISSION_GRANTED;
+
+            if (needsRead || needsWrite) {
+                // no permission yet
+                return false;
+            }
+        } // if android-m
+
+        // already has permission.
+        return true;
+    }
+
+    /**
+     * called in onRequestPermissionsResult().
+     *
+     * @return true if just received permissions. else false and calling finish
+     */
+    public static boolean receivedPermissionsOrFinish(Activity activity, int requestCode,
+                                  @NonNull String[] permissions, @NonNull int[] grantResults) {
+        if (requestCode == REQUEST_CODE_STORAGE) {
+            if ( (grantResults.length == 2)
+                  && (grantResults[0] == PackageManager.PERMISSION_GRANTED)
+                  && (grantResults[1] == PackageManager.PERMISSION_GRANTED)) {
+                return true;
+            } else {
+                showNowPermissionMessage(activity);
+                activity.finish();
+            }
+        }
+        return false;
+    }
+
+    public static void showNowPermissionMessage(Activity activity) {
+        String format = activity.getString(R.string.ERR_NO_WRITE_PERMISSIONS);
+
+        String msg = String.format(
+                format,
+                "",
+                "");
+
+        Toast.makeText(activity, msg, Toast.LENGTH_LONG).show();
+    }
+}

--- a/app/src/main/java/nl/asymmetrics/droidshows/utils/PermissionHelper.java
+++ b/app/src/main/java/nl/asymmetrics/droidshows/utils/PermissionHelper.java
@@ -39,16 +39,13 @@ import nl.asymmetrics.droidshows.R;
 
 public class PermissionHelper {
     /**
-     * Id to identify a Storage permission request.
-     */
-    private static final int REQUEST_CODE_STORAGE = 215;
-
-    /**
      * Permissions required to read and write Storage.
      */
     private static final String[] PERMISSIONS_STORAGE = {Manifest.permission.READ_EXTERNAL_STORAGE,
             Manifest.permission.WRITE_EXTERNAL_STORAGE};
-    public static final boolean REQURES_PERMISSIONS = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
+
+    //** if true use Permissoins and DocumentFileApi. if false : old android devices - no permission api required
+    public static final boolean USE_NEW_PERMISSIONS_FILE_API = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
 
     private PermissionHelper() {/*hide public constructor*/};
     /**
@@ -56,10 +53,10 @@ public class PermissionHelper {
      *
      * @return true if has-permissions. else false and request permissions
      * */
-    public static boolean hasPermissionOrRequest(Activity context) {
+    public static boolean hasPermissionOrRequest(Activity context, int requestCode) {
         if (!hasPermission(context)) {
             // Storage permission has not been requeste yet. Request for first time.
-            ActivityCompat.requestPermissions(context, PERMISSIONS_STORAGE, REQUEST_CODE_STORAGE);
+            ActivityCompat.requestPermissions(context, PERMISSIONS_STORAGE, requestCode);
             // no permission yet
             return false;
         } // if android-m
@@ -72,7 +69,7 @@ public class PermissionHelper {
      * @return true if has-(runtime-)permissions.
      * */
     public static boolean hasPermission(Activity context) {
-        if (REQURES_PERMISSIONS) {
+        if (USE_NEW_PERMISSIONS_FILE_API) {
             boolean needsRead = ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE)
                     != PackageManager.PERMISSION_GRANTED;
 
@@ -94,17 +91,15 @@ public class PermissionHelper {
      *
      * @return true if just received permissions. else false and calling finish
      */
-    public static boolean receivedPermissionsOrFinish(Activity activity, int requestCode,
-                                  @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (requestCode == REQUEST_CODE_STORAGE) {
-            if ( (grantResults.length == 2)
-                  && (grantResults[0] == PackageManager.PERMISSION_GRANTED)
-                  && (grantResults[1] == PackageManager.PERMISSION_GRANTED)) {
-                return true;
-            } else {
-                showNowPermissionMessage(activity);
-                activity.finish();
-            }
+    public static boolean receivedPermissionsOrFinish(Activity activity,
+                                                      @NonNull int[] grantResults) {
+        if ( (grantResults.length == 2)
+              && (grantResults[0] == PackageManager.PERMISSION_GRANTED)
+              && (grantResults[1] == PackageManager.PERMISSION_GRANTED)) {
+            return true;
+        } else {
+            showNowPermissionMessage(activity);
+            activity.finish();
         }
         return false;
     }

--- a/app/src/main/res/layout/add_serie.xml
+++ b/app/src/main/res/layout/add_serie.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:orientation="vertical" android:layout_width="fill_parent" android:layout_height="fill_parent" android:keepScreenOn="true">
 	<TextView android:layout_width="fill_parent" android:layout_height="wrap_content" android:paddingTop="4dp" android:paddingBottom="4dp" style="?android:attr/listSeparatorTextViewStyle" android:id="@+id/add_serie_title"/>
-	<Button android:id="@+id/change_language" android:layout_width="fill_parent" android:layout_height="wrap_content" android:onClick="changeLanguage"/>
+	<Button android:id="@+id/change_language" android:layout_width="match_parent" android:text="@string/dialog_change_language"
+		android:layout_height="wrap_content" android:onClick="changeLanguage"/>
 	<ListView android:layout_width="fill_parent" android:layout_height="fill_parent" android:id="@+id/android:list"/>
 	<TextView android:id="@+id/android:empty" android:layout_width="fill_parent" android:layout_height="fill_parent" android:padding="6dp" android:text="@string/layout_search_no_items"/>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,4 +131,7 @@
 <string name="series_actors">Actors:</string>
 <string name="showstatus_continuing">continuing</string>
 <string name="showstatus_ended">ended</string>
+
+<string name="ERR_NO_WRITE_PERMISSIONS">No Permissions to write to %1$s %2$s.</string>
+
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
-android.defaults.buildfeatures.buildconfig=true
+# true means resource ids cannot be use switch(id)
 android.nonFinalResIds=false
+
+# note: android.nonTransitiveRClass=true is not compatible with deprecated ListActivity
 android.nonTransitiveRClass=false
 
 android.useAndroidX=true


### PR DESCRIPTION
Code changes:

Added code required by android-6 (or later) for existing backup/restoring functionality.:

* ask user for permission READ_EXTERNAL_STORAGE or WRITE_EXTERNAL_STORAGE
* Using StorageAccessFramework to get Backup-output-Directory
* Using StorageAccessFramework to pick restore-file from

No other code changes
